### PR TITLE
Added rounded hours attribute to TimeEntry object

### DIFF
--- a/lib/time-entry.ex
+++ b/lib/time-entry.ex
@@ -18,6 +18,7 @@ defmodule Harvex.TimeEntry do
     :external_reference,
     :invoice,
     :hours,
+    :rounded_hours,
     :notes,
     :is_locked,
     :locked_reason,


### PR DESCRIPTION
Looks like Harvest added a `rounded_time` attribute for it TimeEntry object. See harvest time entry documentation [here](https://help.getharvest.com/api-v2/timesheets-api/timesheets/time-entries/)